### PR TITLE
Abbrechen des Verbindungsaufbaus

### DIFF
--- a/DM7_PPLUS_Integration/Implementierung/Client/Connector.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Client/Connector.cs
@@ -107,7 +107,7 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
                 throw new ConnectionErrorException(
                     $"Fehler beim Verbindungsaufbau mit P-PLUS (unbekannte Antwort: {result.GetType().Name})");
 
-            });
+            }, cancellationToken_Verbindung);
         }
 
 

--- a/DM7_PPLUS_Integration/Implementierung/Client/Ebene_2_Proxy_Factory.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Client/Ebene_2_Proxy_Factory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Protokoll;
 
@@ -6,6 +7,6 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
 {
     public interface Ebene_2_Proxy_Factory
     {
-        Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log);
+        Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log, CancellationToken cancellationToken_Verbindung);
     }
 }

--- a/DM7_PPLUS_Integration/Implementierung/Client/LoopbackFactory.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Client/LoopbackFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Protokoll;
 using DM7_PPLUS_Integration.Implementierung.Server;
@@ -26,7 +27,7 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
             _disposegroup = disposegroup;
         }
 
-        public Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log)
+        public Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log, CancellationToken cancellationToken_Verbindung)
         {
             var task =
                 new Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau,

--- a/DM7_PPLUS_Integration/Implementierung/Client/NetMQ_Client.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Client/NetMQ_Client.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Protokoll;
 using DM7_PPLUS_Integration.Implementierung.Server;
@@ -19,7 +20,7 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
         /// <summary>
         ///  Sendet serialisierte Nachrichten über ZeroMQ an NetMQ_Server
         /// </summary>
-        public NetMQ_Client(string networkaddress, Log log, DisposeGroup disposegroup) : base(disposegroup)
+        public NetMQ_Client(string networkaddress, Log log, DisposeGroup disposegroup, CancellationToken cancellationToken_Verbindung) : base(disposegroup)
         {
             _log = log;
             _notifications = new Subject<byte[]>();
@@ -54,6 +55,8 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
                 _log.Debug("NetMQ Poller wird geschlossen...");
                 _poller.Dispose();
             });
+
+            cancellationToken_Verbindung.Register(disposegroup.Dispose);
         }
 
         private void _subscriber_socket_receive_ready(object sender, NetMQSocketEventArgs e)

--- a/DM7_PPLUS_Integration/Implementierung/Client/NetMQ_Factory.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Client/NetMQ_Factory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Protokoll;
 using DM7_PPLUS_Integration.Implementierung.Shared;
@@ -14,13 +15,13 @@ namespace DM7_PPLUS_Integration.Implementierung.Client
             _disposegroup = disposegroup;
         }
 
-        public Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log)
+        public Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau, Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>> Connect_Ebene_2(string networkAddress, Log log, CancellationToken cancellationToken_Verbindung)
         {
             var task =
                 new Task<Tuple<Ebene_2_Protokoll__Verbindungsaufbau,
                     Ebene_2_Protokoll__API_Level_unabhaengige_Uebertragung>>(() =>
                 {
-                    var client = new NetMQ_Client(networkAddress, log, _disposegroup);
+                    var client = new NetMQ_Client(networkAddress, log, _disposegroup, cancellationToken_Verbindung);
                     var serializer = new Data_Proxy(client, _disposegroup);
                     var connector = new Service_Proxy(client, _disposegroup);
 

--- a/DM7_PPLUS_Integration/Implementierung/Testing/TestConnector.cs
+++ b/DM7_PPLUS_Integration/Implementierung/Testing/TestConnector.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Client;
 
 namespace DM7_PPLUS_Integration.Implementierung.Testing
@@ -7,12 +8,12 @@ namespace DM7_PPLUS_Integration.Implementierung.Testing
     {
         public static Task<Level_0_Test_API> Instance_API_level_0_nur_fuer_Testzwecke(string networkAddress, Log log, Ebene_2_Proxy_Factory factory = null)
         {
-            return Connector.Instance_API_level_0_nur_fuer_Testzwecke(networkAddress, log, factory);
+            return Connector.Instance_API_level_0_nur_fuer_Testzwecke(networkAddress, log, CancellationToken.None, factory);
         }
 
-        public static Task<DM7_PPLUS_API> Instance_API_Level_1(string networkAddress, Log log, Ebene_2_Proxy_Factory factory = null)
+        public static Task<DM7_PPLUS_API> Instance_API_Level_1(string networkAddress, Log log, CancellationToken cancellationToken_Verbindung, Ebene_2_Proxy_Factory factory = null)
         {
-            return Connector.Instance_API_Level_1(networkAddress, log, factory);
+            return Connector.Instance_API_Level_1(networkAddress, log, cancellationToken_Verbindung, factory);
         }
     }
 }

--- a/DM7_PPLUS_Integration/Public/Daten/Mitarbeiterdatensaetze.cs
+++ b/DM7_PPLUS_Integration/Public/Daten/Mitarbeiterdatensaetze.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace DM7_PPLUS_Integration.Daten
 {

--- a/DM7_PPLUS_Integration/Public/PPLUS.cs
+++ b/DM7_PPLUS_Integration/Public/PPLUS.cs
@@ -11,10 +11,11 @@ namespace DM7_PPLUS_Integration
         /// </summary>
         /// <param name="network_address">Netzwerkadresse des P-PLUS DM7_PPLUS_Integrations Endpunktes</param>
         /// <param name="log">Adapter für Statusmeldungen der DM7_PPLUS_Integrationsschnittstelle</param>
+        /// <param name="cancellationToken_Verbindung">Token zum kontrollierten Abbruch während des Verbindens mit dem Server</param>
         /// <returns>Instanz der DM7_PPLUS_Integrationsschnittstelle</returns>
-        public static Task<DM7_PPLUS_API> Connect(string network_address, Log log)
+        public static Task<DM7_PPLUS_API> Connect(string network_address, Log log, CancellationToken cancellationToken_Verbindung)
         {
-            return Connector.Instance_API_Level_1(network_address, log, CancellationToken.None);
+            return Connector.Instance_API_Level_1(network_address, log, cancellationToken_Verbindung);
         }
     }
 }

--- a/DM7_PPLUS_Integration/Public/PPLUS.cs
+++ b/DM7_PPLUS_Integration/Public/PPLUS.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration.Implementierung.Client;
 
@@ -13,7 +14,7 @@ namespace DM7_PPLUS_Integration
         /// <returns>Instanz der DM7_PPLUS_Integrationsschnittstelle</returns>
         public static Task<DM7_PPLUS_API> Connect(string network_address, Log log)
         {
-            return Connector.Instance_API_Level_1(network_address, log);
+            return Connector.Instance_API_Level_1(network_address, log, CancellationToken.None);
         }
     }
 }

--- a/DM7_PPLUS_Integration_Specs/API_Tests.cs
+++ b/DM7_PPLUS_Integration_Specs/API_Tests.cs
@@ -143,7 +143,7 @@ namespace DM7_PPLUS_Integration_Specs
                 start();
             };
 
-            _proxy = PPLUS.Connect("tcp://127.0.0.1:" + port, new TestLog("[client] ")).Result;
+            _proxy = PPLUS.Connect("tcp://127.0.0.1:" + port, new TestLog("[client] "), CancellationToken.None).Result;
             Setup_Testframework(_proxy, server);
         }
 

--- a/DM7_PPLUS_Integration_Specs/API_Tests.cs
+++ b/DM7_PPLUS_Integration_Specs/API_Tests.cs
@@ -32,7 +32,7 @@ namespace DM7_PPLUS_Integration_Specs
             var log = new TestLog("[server] ");
 
             var host = DM7_PPLUS_Host.Starten(server, log, ex => Assert.Fail(ex.ToString()));
-            var proxy = TestConnector.Instance_API_Level_1("test://test", new TestLog("[client] "), new LoopbackFactory(host, 2)).Result;
+            var proxy = TestConnector.Instance_API_Level_1("test://test", new TestLog("[client] "), CancellationToken.None, new LoopbackFactory(host, 2)).Result;
 
             Setup_Testframework(proxy, server);
         }
@@ -47,7 +47,7 @@ namespace DM7_PPLUS_Integration_Specs
             var log = new TestLog("[server] ");
 
             var host = DM7_PPLUS_Host.Starten(server, log, ex => Assert.Fail(ex.ToString()));
-            var proxy = TestConnector.Instance_API_Level_1("test://test", new TestLog("[client] "), new LoopbackFactory(host, 3)).Result;
+            var proxy = TestConnector.Instance_API_Level_1("test://test", new TestLog("[client] "), CancellationToken.None, new LoopbackFactory(host, 3)).Result;
 
             Setup_Testframework(proxy, server);
         }

--- a/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
+++ b/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.CodeDom;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +25,6 @@ namespace DM7_PPLUS_Integration_Specs
         }
 
 
-        // TODO: Verbindungsaufbau blockiert im Moment unendlich lange. Es muss möglich sein, den Verbindungsaufbau abzubrechen...
         [Test]
         public void Verbindungsaufbau_kann_abgebrochen_werden__Modell_1_Timeout()
         {

--- a/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
+++ b/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DM7_PPLUS_Integration;
 using DM7_PPLUS_Integration.Implementierung.Client;
@@ -14,21 +15,27 @@ namespace DM7_PPLUS_Integration_Specs
     [TestFixture]
     public class VerbindungsaufbauTests_async
     {
-        private Task<DM7_PPLUS_API> Verbindungsaufbau_1_async(string netzwerkadresse, TimeSpan connection_timeout)
+        private Task<DM7_PPLUS_API> Verbindungsaufbau_1_async(string netzwerkadresse, out Action cancel)
         {
+            cancel = () => { throw new NotImplementedException(); };
             return TestConnector.Instance_API_Level_1(netzwerkadresse, new TestLog("[client] "));
         }
 
-        [Test, Ignore]
-        public void Verbindungsaufbau_kann_abgebrochen_werden()
-        {
-            Action action = () =>
-            {
-                var task = Verbindungsaufbau_1_async("tcp://127.0.0.1:4711", TimeSpan.FromMilliseconds(50));
-                task.Wait(TimeSpan.FromMilliseconds(100));
-            };
 
-            action.ShouldThrow<ConnectionErrorException>();
+        // TODO: Verbindungsaufbau blockiert im Moment unendlich lange. Es muss möglich sein, den Verbindungsaufbau abzubrechen...
+        [Test]
+        public void Verbindungsaufbau_kann_abgebrochen_werden__Modell_1_Timeout()
+        {
+            Action cancel;
+            var task = Verbindungsaufbau_1_async("tcp://127.0.0.1:4711", out cancel);
+            task.Wait(TimeSpan.FromMilliseconds(100));
+            Warte_auf_Konsistenz();
+            cancel();
+            Assert.IsTrue(task.IsCanceled);
+        }
+
+        private void Warte_auf_Konsistenz()
+        {
         }
     }
 

--- a/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
+++ b/DM7_PPLUS_Integration_Specs/VerbindungsaufbauTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.CodeDom;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,8 +18,11 @@ namespace DM7_PPLUS_Integration_Specs
     {
         private Task<DM7_PPLUS_API> Verbindungsaufbau_1_async(string netzwerkadresse, out Action cancel)
         {
-            cancel = () => { throw new NotImplementedException(); };
-            return TestConnector.Instance_API_Level_1(netzwerkadresse, new TestLog("[client] "));
+            var cancellationTokenSource= new CancellationTokenSource();
+            var cancellationToken_Verbindung = cancellationTokenSource.Token;
+
+            cancel = () => { cancellationTokenSource.Cancel(); };
+            return TestConnector.Instance_API_Level_1(netzwerkadresse, new TestLog("[client] "), cancellationToken_Verbindung);
         }
 
 
@@ -53,7 +57,7 @@ namespace DM7_PPLUS_Integration_Specs
 
         private DM7_PPLUS_API Verbindungsaufbau_1(string netzwerkadresse)
         {
-            return TestConnector.Instance_API_Level_1(netzwerkadresse, new TestLog("[client] "), _factory).Result;
+            return TestConnector.Instance_API_Level_1(netzwerkadresse, new TestLog("[client] "), CancellationToken.None, _factory).Result;
         }
 
         private void Server_kompatibel_mit_API_level(int server_min_api_level, int server_max_api_level)

--- a/Demo_Implementierung/DemoClientImplementierung.cs
+++ b/Demo_Implementierung/DemoClientImplementierung.cs
@@ -50,8 +50,11 @@ namespace Demo_Implementierung
 
             var url = (args.Length > 0) ? args[0] : DEMO_URL;
 
+            var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken_Verbindung = cancellationTokenSource.Token;
+
             // Rückgabe von Connect muss Disposed werden, um alle Verbindungen zu schließen
-            using (var api = PPLUS.Connect(url, log).Result)
+            using (var api = PPLUS.Connect(url, log, cancellationToken_Verbindung).Result)
             {
                 if (api==null) throw new ApplicationException("P-PLUS API war unterwarteterweise <null>.");
 
@@ -72,6 +75,7 @@ namespace Demo_Implementierung
                 {
                     Console.Out.WriteLine("- Press any key to quit.");
                     Console.ReadKey();
+                    cancellationTokenSource.Cancel();
                 }
 
             }


### PR DESCRIPTION
**breaking change**

Die Connect Methode erwartet als dritten Parameter ein CancellationToken.

Damit kann ein laufender Verbindungsaufbau abgebrochen werden, beispielsweise durch extern festgestellten Timeout oder Benutzeranforderung. Alternativ kann CancellationToken.None übergeben werden, dann bricht der Verbindungsaufbau nie ab. Mittels .Result kann dann ewig auf den Aufbau einer Verbindung gewartet werden oder mittels .ContinueWith asynchron auf den erfolgreichen Verbindungsaufbau reagiert werden.

_Achtung_: Im Falle eines Verbindungsabbruchs mittels CancellationTokenSource gibt der Task dann **null** als Result zurück!

Die DemoClientImplementierung ist um den Fall eines Abbruchs nach Benutzeraufforderung erweitert.